### PR TITLE
Fix proof for leAsym and change `cong`

### DIFF
--- a/WhyDependentTypesMatter.hs
+++ b/WhyDependentTypesMatter.hs
@@ -352,12 +352,9 @@ leTrans :: LEq x y -> LEq y z -> LEq x z
 leTrans LeZ       yz      = LeZ
 leTrans (LeS xy) (LeS yz) = LeS (leTrans xy yz)
 
-leASym :: LEq x y -> LEq y x -> x :~: x
+leASym :: LEq x y -> LEq y x -> x :~: y
 leASym  LeZ      LeZ     = Refl
-leASym (LeS xy) (LeS yx) = Refl
-
--- Second equation for leASym is surprisingly simple. I admit I don't fully
--- understand why I could simply use refl here, without doing inductive proof.
+leASym (LeS xy) (LeS yx) = cong SSucc (leASym xy yx)
 
 -- Section 5.2 :: Locally Sorted Lists
 -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Good news! I know the answer to:

``` haskell
--- Second equation for leASym is surprisingly simple. I admit I don't fully
--- understand why I could simply use refl here, without doing inductive proof.
```

You had a typo in the type signature: `leASym :: LEq x y -> LEq y x -> x :~: x` notice the `x :~: x` at the end.  It's very simple to proof that ;), but you meant to say that if `x <= y` and `y <= x` then `x :~: y`.

I fixed that and wondered why `cong` takes a function from SNat to SNat because it is obviously useless in our case for the proof.  Turns out you actually don't need that argument at all, so I took the freedom to  remove it.

Best,
Markus
